### PR TITLE
[CTE 2046] Changed dynamodb.js to skip mapping the committee topic. So it is no …

### DIFF
--- a/dynamodb/dynamodb.js
+++ b/dynamodb/dynamodb.js
@@ -59,11 +59,12 @@ const dynamodb = {
           title: 'MPs\' and Lords\' accountability',
           items: formatted.filter(val => val.type == 'accountability').sort(helpers.sortAlphabetically)
         },
-        {
-          id: 'committee',
-          title: 'Committee updates',
-          items: formatted.filter(val => val.type == 'committee').sort(helpers.sortAlphabetically),
-        },
+        // Skip mapping the committee topic
+        //{
+        //  id: 'committee',
+        //  title: 'Committee updates',
+        //  items: formatted.filter(val => val.type == 'committee').sort(helpers.sortAlphabetically),
+        //},
         {
           id: 'bill',
           title: 'Bill updates',


### PR DESCRIPTION
…longer displayed to the user as an option to subscribe.

topics.model.js was calling formatItems() which was mapping the topics from dynamodb to an array called automated[].
Those topics where then displayed to the user in the view list.pug L42.

This is a temporary fix as currently notifications for committees has been disabled as it was broken and sending lots of redundant emails.